### PR TITLE
remove now-incorrect build step

### DIFF
--- a/.github/workflows/process_docs_changes.yml
+++ b/.github/workflows/process_docs_changes.yml
@@ -53,10 +53,6 @@ jobs:
         run: |
           bb script/update_docs_for_branchname.clj "$MAIN_REPO_BRANCH"
 
-      - name: Update docs
-        run: |
-          ./script/docs "$MAIN_REPO_BRANCH" --set-version "$MAIN_REPO_BRANCH"
-
       - name: "Lint the markdown"
         run: |
           yarn lint-markdown


### PR DESCRIPTION
I accidently left the original (wrong) build step in. Now this is handled by the step:

```
bb script/update_docs_for_branchname.clj "$MAIN_REPO_BRANCH"
```