### PR TITLE
copy exclude-embedding-sdk-config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,7 @@ collections:
 defaults:
     - {scope: {type: docs}, values: {layout: new-docs, permalink: '/:collection/:path'}}
 exclude:
+    - _docs/**/embedding/sdk/api/snippets/**
     - svg-icon-list.html
     - Gemfile
     - Gemfile.lock


### PR DESCRIPTION
- Update _config.yml to exclude embedding-sdk from the build process
- This change is necessary to prevent the embedding-sdk from being included in the final build output, as it is not needed for the current project requirements.
- This was coppied from the original repo.