### PR TITLE
Generate raw Markdown files for AI agents to reference

### DIFF
--- a/_plugins/copy_raw_markdown.rb
+++ b/_plugins/copy_raw_markdown.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Jekyll plugin to copy raw markdown files to the _site directory
+# This allows llms.txt and AI agents to reference raw .md files.
+# Example: https://www.metabase.com/docs/latest/data-modeling/models.md
+Jekyll::Hooks.register :site, :post_write do |site|
+  # Get the source and destination directories
+  source_dir = site.source
+  dest_dir = site.dest
+
+  # Process the docs collection
+  docs_collection = site.collections['docs']
+  next unless docs_collection
+
+  docs_collection.docs.each do |doc|
+    relative_source_path = doc.relative_path
+
+    # Skip if not a markdown file
+    next unless relative_source_path.end_with?('.md')
+
+    source_file = File.join(source_dir, relative_source_path)
+    dest_path = relative_source_path.sub(/^_docs\//, 'docs/')
+    dest_file = File.join(dest_dir, dest_path)
+
+    # Create the destination directory
+    FileUtils.mkdir_p(File.dirname(dest_file))
+
+    # Copy the markdown file
+    FileUtils.cp(source_file, dest_file)
+
+    Jekyll.logger.debug "Copied raw markdown:", "#{relative_source_path} -> #{dest_path}"
+  end
+
+  Jekyll.logger.info "Raw markdown files:", "Copied all .md files to site output"
+end

--- a/_plugins/jekyll_copy_raw_markdown_plugin.rb
+++ b/_plugins/jekyll_copy_raw_markdown_plugin.rb
@@ -21,12 +21,14 @@ Jekyll::Hooks.register :site, :post_write do |site|
     source_file = File.join(source_dir, relative_source_path)
     dest_path = relative_source_path.sub(/^_docs\//, 'docs/')
     dest_file = File.join(dest_dir, dest_path)
+    content = File.read(source_file)
 
     # Create the destination directory
     FileUtils.mkdir_p(File.dirname(dest_file))
 
-    # Copy the markdown file
-    FileUtils.cp(source_file, dest_file)
+    # Strip YAML frontmatter
+    content_without_frontmatter = content.sub(/\A---\s*\n.*?\n---\s*\n/m, '')
+    File.write(dest_file, content_without_frontmatter)
 
     Jekyll.logger.debug "Copied raw markdown:", "#{relative_source_path} -> #{dest_path}"
   end

--- a/_plugins/jekyll_copy_raw_markdown_plugin.rb
+++ b/_plugins/jekyll_copy_raw_markdown_plugin.rb
@@ -28,7 +28,11 @@ Jekyll::Hooks.register :site, :post_write do |site|
 
     # Strip YAML frontmatter
     content_without_frontmatter = content.sub(/\A---\s*\n.*?\n---\s*\n/m, '')
-    File.write(dest_file, content_without_frontmatter)
+
+    # Strip Liquid templates in {% ... %} tags
+    content_clean = content_without_frontmatter.gsub(/\{%.*?%\}/m, '')
+
+    File.write(dest_file, content_clean)
 
     Jekyll.logger.debug "Copied raw markdown:", "#{relative_source_path} -> #{dest_path}"
   end


### PR DESCRIPTION
Closes [EMB-1161](https://linear.app/metabase/issue/EMB-1161/generate-raw-markdown-files-in-jekyll-docs-site-for-ai-agents-to)

Most llms.txt files are simply links to a bunch of docs, for example bun's llms.txt:

```
## Docs

- [Bytecode Caching](https://bun.com/docs/bundler/bytecode.md): Speed up JavaScript execution with bytecode caching in Bun's bundler
- [CSS](https://bun.com/docs/bundler/css.md): Bun's bundler has built-in support for CSS with modern features
```

This keeps the llms.txt small. See other examples in [https://directory.llmstxt.cloud](https://directory.llmstxt.cloud/?page=2).

This is why we want to expose the raw .md Markdown files to be web-accessible, so that we can link them inside of llms.txt and AI agents can easily access those raw Markdown files.

## Demo

Visiting `/docs/latest/documents/introduction.md` gives us this:

<img width="2312" height="1524" alt="CleanShot 2568-12-26 at 23 26 49@2x" src="https://github.com/user-attachments/assets/7868679b-46d4-47d4-b691-71f80d38db29" />
