### PR TITLE
Make docs work locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,21 @@ tmp/
 /htmlproofer.out
 /.clj-kondo/
 /.lsp/
+
+# ignore dirs we pull in from the website repo
+/_data/
+/_examples/
+/_glossary/
+/_headers/
+/_help/
+/_includes/
+/_layouts/
+/_plugins/
+/_posts/
+/_sass/
+/css/
+/files/
+/images/
+/js/
+/learn/
+/redirects/

--- a/script/server
+++ b/script/server
@@ -4,4 +4,6 @@
 # Run the jekyll server
 rm -rf _site
 
+bb ./sync_repo.clj --from-repo ../../metabase.github.io
+
 bundle exec jekyll serve --baseurl '' --watch --incremental

--- a/script/server
+++ b/script/server
@@ -4,6 +4,6 @@
 # Run the jekyll server
 rm -rf _site
 
-bb ./sync_repo.clj --from-repo ../../metabase.github.io
+bb ./script/sync_repo.clj --from-repo ../metabase.github.io
 
 bundle exec jekyll serve --baseurl '' --watch --incremental


### PR DESCRIPTION
One little baby step toward making this repo work a bit more independently

1. calls the sync script to slurp in dependencies from metabase.github.io, assuming it's a sibling folder to docs.metabase.github.io
2. gitignores all the stuff it slurps in

To test:

in the docs repo:
- run `bundle install`
- run `./script/server`

You should see the Metabase website, but it's only rendering some things, most importantly, docs!