### PR TITLE
Deploy combined sitemap - Docs

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,18 @@
+---
+layout: null
+title: Docs Sitemap
+permalink: /docs/sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% assign latest_docs = site.docs | where_exp: "doc", "doc.url contains '/docs/latest/'" | sort: "url" %}
+{% for doc in latest_docs %}
+  {% assign canonical = doc.canonical | default: "" %}
+  {% unless canonical contains "http" or doc.url contains ".json" %}
+    {% assign loc = doc.url | replace: "/index", "/" | replace: "/.html", "/" | replace: ".html", "" %}
+  <url>
+    <loc>https://www.metabase.com{{ loc | xml_escape }}</loc>
+  </url>
+  {% endunless %}
+{% endfor %}
+</urlset>

--- a/script/util.clj
+++ b/script/util.clj
@@ -66,6 +66,7 @@
 
 (def artifacts-to-include ["_data/shared_chrome.json"
                            "_site/docs/all.html"
+                           "_site/docs/sitemap.xml"
                            "_site/docs/llms.txt"
                            "_site/docs/llms-embedding-full.txt"
                            "_site/docs/llms-agent-api-full.txt"])


### PR DESCRIPTION
Fixes GRO-473, GRO-504

- Creates the docs sitemap under `docs/sitemap.xml`, following the same non-versioned route exclusion rule from the original sitemap build

This sitemap will be pointed to by the soon-to-change https://www.metabase.com/sitemap.xml file, which will be come an index.

See also: https://github.com/metabase/metabase.github.io/pull/5874