### PR TITLE
GRO-558 prevent vwo from loading on every page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -67,8 +67,7 @@
 
   <meta content="no-referrer-when-downgrade" name="referrer" />
 
-  {% comment %} TODO: Remove force_enabled when New Pricing a/b test is complete (GRO-415) {% endcomment %}
-  {% include marketing-vwo.html force_enabled=true %}
+  {% include marketing-vwo.html %}
 
    {% if jekyll.environment == "production" %}
      {% include sentry.html %}


### PR DESCRIPTION
[GRO-558](https://linear.app/metabase/issue/GRO-558/promote-new-new-pricing-page-to-be-the-only-pricing-page)

We no longer need to load vwo on every page because the new new pricing a/b test is over