### PR TITLE
Add docs site rewrites to source control

### DIFF
--- a/.github/workflows/update-redirects.yml
+++ b/.github/workflows/update-redirects.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  update:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/update-redirects.yml
+++ b/.github/workflows/update-redirects.yml
@@ -1,0 +1,67 @@
+name: Update Redirects
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - redirects.json
+      - .github/workflows/update-redirects.yml
+  push:
+    branches:
+      - master
+    paths:
+      - redirects.json
+      - .github/workflows/update-redirects.yml
+
+env:
+  STAGING_APP_ID: dkkh35gceu2po
+  PROD_APP_ID: ????
+
+concurrency:
+  group: update-redirects-${{ github.ref == 'refs/heads/master' && 'prod' || 'staging' }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: redirects.json
+
+      - name: Check redirects.json
+        run: |
+          if ! jq -e . redirects.json > /dev/null; then
+            echo "Invalid JSON in redirects.json"
+            exit 1
+          fi
+
+      - name: Get App Id
+        run: | # sh
+          if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            echo "APP_ID=${{ env.PROD_APP_ID }}" >> $GITHUB_ENV
+          else
+            echo "APP_ID=${{ env.STAGING_APP_ID }}" >> $GITHUB_ENV
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AMPLIFY_DEPLOY_ROLE }}
+          aws-region: us-east-1
+
+      - name: Deploy redirects.json to Amplify
+        run: |
+          RULES=$(jq -c . redirects.json)
+          aws amplify update-app \
+            --app-id "$APP_ID" \
+            --custom-rules "$RULES"
+
+
+
+

--- a/.github/workflows/update-redirects.yml
+++ b/.github/workflows/update-redirects.yml
@@ -41,18 +41,20 @@ jobs:
             exit 1
           fi
 
-      - name: Get App Id
+      - name: Get App Id & Deploy Role
         run: | # sh
           if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
             echo "APP_ID=${{ env.PROD_APP_ID }}" >> $GITHUB_ENV
+            echo "DEPLOY_ROLE=${{ secrets.AMPLIFY_DEPLOY_ROLE_PROD }}" >> $GITHUB_ENV
           else
             echo "APP_ID=${{ env.STAGING_APP_ID }}" >> $GITHUB_ENV
+            echo "DEPLOY_ROLE=${{ secrets.AMPLIFY_DEPLOY_ROLE_DEV }}" >> $GITHUB_ENV
           fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AMPLIFY_DEPLOY_ROLE }}
+          role-to-assume: ${{ env.DEPLOY_ROLE }}
           aws-region: us-east-1
 
       - name: Deploy redirects.json to Amplify

--- a/.github/workflows/update-redirects.yml
+++ b/.github/workflows/update-redirects.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   STAGING_APP_ID: dkkh35gceu2po
-  PROD_APP_ID: ????
+  PROD_APP_ID: d1c991nkitx5oc
 
 concurrency:
   group: update-redirects-${{ github.ref == 'refs/heads/master' && 'prod' || 'staging' }}

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,42 @@
+[
+  {
+    "source": "/docs",
+    "status": "301",
+    "target": "/docs/latest/"
+  },
+  {
+    "source": "/docs/",
+    "status": "301",
+    "target": "/docs/latest/"
+  },
+  {
+    "source": "/docs/all/",
+    "status": "301",
+    "target": "/docs/all"
+  },
+  {
+    "source": "/docs/all",
+    "status": "200",
+    "target": "/docs/all"
+  },
+  {
+    "source": "/docs/sitemap.xml/",
+    "status": "301",
+    "target": "/docs/sitemap.xml"
+  },
+  {
+    "source": "/docs/sitemap.xml",
+    "status": "200",
+    "target": "/docs/sitemap.xml"
+  },
+  {
+    "source": "/docs/<version>",
+    "status": "301",
+    "target": "/docs/<version>/"
+  },
+  {
+    "source": "/docs/<*>",
+    "status": "404-200",
+    "target": "/docs/404.html"
+  }
+]


### PR DESCRIPTION
We need these in source control, and we need a programatic way to deploy them in both dev and prod.

- Adds all rewrite/redirect rules to source control in a json
- if the json changes in a PR we deploy to Dev
- when a changed json is merged to master, we deploy to Prod

see also: https://github.com/metabase/metabase.github.io/pull/5923